### PR TITLE
Functionality for playing artist or album

### DIFF
--- a/spotify-api.el
+++ b/spotify-api.el
@@ -152,8 +152,12 @@ JSON response."
   (spotify-get-item-name (spotify-get-track-album json)))
 
 (defun spotify-get-track-artist (json)
-  "Returns the first artist from the given track object."
-  (spotify-get-item-name (first (gethash 'artists json))))
+  "Returns the first simplified artist object from the given track object."
+  (first (gethash 'artists json)))
+
+(defun spotify-get-track-artist-name (json)
+  "Returns the first artist name from the given track object."
+  (spotify-get-item-name (spotify-get-track-artist json)))
 
 (defun spotify-get-track-popularity (json)
   "Returns the popularity from the given track/album/artist object."

--- a/spotify-track-search.el
+++ b/spotify-track-search.el
@@ -33,9 +33,7 @@ Otherwise, play the track selected."
 	   (spotify-track-artist-select))
 	  ((string= "Album" button-selected)
 	   (spotify-track-album-select))
-	  (t (spotify-track-select-default)))
-    )
-  )
+	  (t (spotify-track-select-default)))))
 
 (defun spotify-track-select-default ()
   "Plays the track under the cursor. If the track list represents a playlist,
@@ -54,29 +52,22 @@ be played in the context of its album."
 		      for col-width = (cadr (aref tabulated-list-format i))
 		      while (> pos col-width)
 		      do (decf pos col-width)
-		      finally return i
-		      )))
-      (car (aref tabulated-list-format idx)))
-    )
-  )
+		      finally return i)))
+      (car (aref tabulated-list-format idx)))))
 
 (defun spotify-track-artist-select ()
   "Plays the artist of the track under the cursor."
   (interactive)
   (let ((selected-track-artist
 	 (spotify-get-track-artist (tabulated-list-get-id))))
-    (spotify-play-track nil selected-track-artist)
-    )
-  )
+    (spotify-play-track nil selected-track-artist)))
 
 (defun spotify-track-album-select ()
   "Plays the album of the track under the cursor."
   (interactive)
   (let ((selected-track-album
 	 (spotify-get-track-album (tabulated-list-get-id))))
-    (spotify-play-track nil selected-track-album)
-    )
-  )
+    (spotify-play-track nil selected-track-album)))
 
 (defun spotify-track-playlist-follow ()
   "Adds the current user as the follower of the selected playlist."

--- a/spotify-track-search.el
+++ b/spotify-track-search.el
@@ -33,6 +33,24 @@ be played in the context of its album."
         (spotify-play-track selected-track spotify-selected-playlist)
       (spotify-play-track selected-track (spotify-get-track-album selected-track)))))
 
+(defun spotify-track-artist-select ()
+  "Plays the artist of the track under the cursor."
+  (interactive)
+  (let ((selected-track-artist
+	 (spotify-get-track-artist (tabulated-list-get-id))))
+    (spotify-play-track nil selected-track-artist)
+    )
+  )
+
+(defun spotify-track-album-select ()
+  "Plays the album of the track under the cursor."
+  (interactive)
+  (let ((selected-track-album
+	 (spotify-get-track-album (tabulated-list-get-id))))
+    (spotify-play-track nil selected-track-album)
+    )
+  )
+
 (defun spotify-track-playlist-follow ()
   "Adds the current user as the follower of the selected playlist."
   (interactive)

--- a/spotify-track-search.el
+++ b/spotify-track-search.el
@@ -104,7 +104,7 @@ be played in the context of its album."
   (let (entries)
     (dolist (song songs)
       (when (spotify-is-track-playable song)
-        (let ((artist-name (spotify-get-track-artist song))
+        (let ((artist-name (spotify-get-track-artist-name song))
               (album-name (spotify-get-track-album-name song)))
           (push (list song
                       (vector (number-to-string (spotify-get-track-number song))

--- a/spotify-track-search.el
+++ b/spotify-track-search.el
@@ -47,13 +47,12 @@ be played in the context of its album."
 
 (defun spotify-track-selected-button-type ()
   (when (button-at (point))
-    (let* ((pos (current-column))
-	   (idx (loop for i from 0 to (1- (length tabulated-list-format))
-		      for col-width = (cadr (aref tabulated-list-format i))
-		      while (> pos col-width)
-		      do (decf pos col-width)
-		      finally return i)))
-      (car (aref tabulated-list-format idx)))))
+    (let* ((format-list (append tabulated-list-format nil)) ;; convert vector to list
+	   (column-widths (-map 'cadr format-list))
+	   (selected-column (--find-index (< it 0)
+					  (cdr (-reductions-from
+						'- (current-column) column-widths)))))
+      (car (aref tabulated-list-format selected-column)))))
 
 (defun spotify-track-artist-select ()
   "Plays the artist of the track under the cursor."

--- a/spotify-track-search.el
+++ b/spotify-track-search.el
@@ -24,6 +24,20 @@
   "Major mode for displaying the track listing returned by a Spotify search.")
 
 (defun spotify-track-select ()
+  "Plays the track, album or artist under the cursor. If the cursor is on a
+button representing an artist or album, start playing that artist or album.
+Otherwise, play the track selected."
+  (interactive)
+  (let ((button-selected (spotify-track-selected-button-type)))
+    (cond ((string= "Artist" button-selected)
+	   (spotify-track-artist-select))
+	  ((string= "Album" button-selected)
+	   (spotify-track-album-select))
+	  (t (spotify-track-select-default)))
+    )
+  )
+
+(defun spotify-track-select-default ()
   "Plays the track under the cursor. If the track list represents a playlist,
 the given track is played in the context of that playlist; otherwise, it will
 be played in the context of its album."
@@ -32,6 +46,19 @@ be played in the context of its album."
     (if (bound-and-true-p spotify-selected-playlist)
         (spotify-play-track selected-track spotify-selected-playlist)
       (spotify-play-track selected-track (spotify-get-track-album selected-track)))))
+
+(defun spotify-track-selected-button-type ()
+  (when (button-at (point))
+    (let* ((pos (current-column))
+	   (idx (loop for i from 0 to (1- (length tabulated-list-format))
+		      for col-width = (cadr (aref tabulated-list-format i))
+		      while (> pos col-width)
+		      do (decf pos col-width)
+		      finally return i
+		      )))
+      (car (aref tabulated-list-format idx)))
+    )
+  )
 
 (defun spotify-track-artist-select ()
   "Plays the artist of the track under the cursor."

--- a/spotify-track-search.el
+++ b/spotify-track-search.el
@@ -28,10 +28,10 @@
 button representing an artist or album, start playing that artist or album.
 Otherwise, play the track selected."
   (interactive)
-  (let ((button-selected (spotify-track-selected-button-type)))
-    (cond ((string= "Artist" button-selected)
+  (let ((button-type (spotify-track-selected-button-type)))
+    (cond ((eq 'artist button-type)
 	   (spotify-track-artist-select))
-	  ((string= "Album" button-selected)
+	  ((eq 'album button-type)
 	   (spotify-track-album-select))
 	  (t (spotify-track-select-default)))))
 
@@ -46,13 +46,9 @@ be played in the context of its album."
       (spotify-play-track selected-track (spotify-get-track-album selected-track)))))
 
 (defun spotify-track-selected-button-type ()
-  (when (button-at (point))
-    (let* ((format-list (append tabulated-list-format nil)) ;; convert vector to list
-	   (column-widths (-map 'cadr format-list))
-	   (selected-column (--find-index (< it 0)
-					  (cdr (-reductions-from
-						'- (current-column) column-widths)))))
-      (car (aref tabulated-list-format selected-column)))))
+  (let ((selected-button (button-at (point))))
+    (when selected-button
+      (button-get selected-button 'artist-or-album))))
 
 (defun spotify-track-artist-select ()
   "Plays the artist of the track under the cursor."
@@ -148,12 +144,14 @@ be played in the context of its album."
                                   (list 'face 'link
                                         'follow-link t
                                         'action `(lambda (_) (spotify-track-search ,(format "artist:\"%s\"" artist-name)))
-                                        'help-echo (format "Show %s's tracks" artist-name)))
+                                        'help-echo (format "Show %s's tracks" artist-name)
+					'artist-or-album 'artist))
                               (cons album-name
                                   (list 'face 'link
                                         'follow-link t
                                         'action `(lambda (_) (spotify-track-search ,(format "artist:\"%s\" album:\"%s\"" artist-name album-name)))
-                                        'help-echo (format "Show %s's tracks" album-name)))
+                                        'help-echo (format "Show %s's tracks" album-name)
+					'artist-or-album 'album))
                               (spotify-get-track-duration-formatted song)
                               (spotify-popularity-bar (spotify-get-track-popularity song))))
                 entries))))

--- a/spotify.el
+++ b/spotify.el
@@ -29,7 +29,6 @@
 
 (require 'json)
 (require 'oauth2)
-(require 'dash)
 (require 'tabulated-list)
 
 (require 'spotify-api)

--- a/spotify.el
+++ b/spotify.el
@@ -29,6 +29,7 @@
 
 (require 'json)
 (require 'oauth2)
+(require 'dash)
 (require 'tabulated-list)
 
 (require 'spotify-api)


### PR DESCRIPTION
As the dbus interface does not support playing a song in a context, the track search mode loses much of its functionality on linux. This PR adds functions for simply playing an artist or album from the track search mode. This is done either by calling one of the two functions `spotify-track-artist-select` or `spotify-track-album-select`, or by calling `spotify-track-select` (`M-RET`) while point is over a button representing an artist or album.