### PR TITLE
Feature/device selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,16 @@
 
 [![asciicast](https://asciinema.org/a/218654.svg)](https://asciinema.org/a/218654)
 
-Spotify.el is a collection of extensions that allows you to control the Spotify
-application from within your favorite text editor.
-
-**Note:** This is _very_ alpha software, and it works only in Mac OS X and Linux.
+Spotify.el is a collection of extensions that allows you to control the Spotify application from
+within your favorite text editor. If you are running on Mac OS X or Linux, you can control the
+locally running instance. If you are running on any platform with a network connection (including
+Windows - and even headless!) and have a Spotify premium subscription, you can control an instance
+of Spotify via the Spotify Connect feature.
 
 ## Features
 
 * Spotify client integration for GNU/Linux (via D-Bus) and OS X (via AppleScript)
+* Device playback display & selection using the Spotify Connect API (requires premium)
 * Communicates with the Spotify API via Oauth2
 * Displays the current track in mode line
 * Create playlists (public or private)
@@ -43,7 +45,9 @@ In order to get the the client ID and client secret, you need to create
 [a Spotify app](https://developer.spotify.com/my-applications), specifying
 <http://localhost:8591/> as the redirect URI.
 
-To use the "Spotify Connect" transport (in order to control players across the network and have the ability to control volume), set `spotify-transport` to `'connect` as follows. This feature requires a Spotify premium subscription.
+To use the "Spotify Connect" transport (vs. controlling only your local instance - though you can
+also control your local instance as well), set `spotify-transport` to `'connect` as follows. This
+feature requires a Spotify premium subscription.
 
 ````el
 (setq spotify-transport 'connect)
@@ -56,9 +60,8 @@ and give your application a name and a description:
 
 ![Creating a Spotify App 1/2](./img/spotify-app-01.png)
 
-At this point, the client ID and the client secret is already available, so set
-those values to `spotify-oauth2-client-id` and `spotify-oauth2-client-secret`,
-respectively.
+At this point, the client ID and the client secret are available, so set those values to
+`spotify-oauth2-client-id` and `spotify-oauth2-client-secret`, respectively.
 
 Then, scroll down a little bit, type <http://localhost:8591/> as the Redirect
 URI for the application, and click **Add**:

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ key bindings:
 | <kbd>t</kbd>     | Lists the tracks of the playlist under the cursor        |
 | <kbd>M-RET</kbd> | Plays the playlist under the cursor                      |
 
-Once you opened the list of tracks of a playlist, you get the following key
+Once you open the list of tracks of a playlist, you get the following key
 bindings in the resulting buffer:
 
 | Key              | Description                                                         |
@@ -222,6 +222,19 @@ Both buffers load the `spotify-remote-mode` by default.
 
 [1] D-Bus implementation for GNU/Linux do not support passing the context, so
 only the track under the cursor will be played
+
+## Selecting a Device for Playback
+
+<kbd>M-x spotify-select-device</kbd> will display a list of devices available for playback in a separate buffer.
+
+Note: use of this feature requires a Spotify premium subscription.
+
+Once you open the list of devices, you get the following key bindings in the resulting buffer:
+
+| Key              | Description                                                         |
+|:-----------------|:--------------------------------------------------------------------|
+| <kbd>RET</kbd>   | Transfer playback to the device under the cursor.                   |
+| <kbd>g</kbd>     | Reloads the list of devices                                         |
 
 ## Donate
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ key bindings:
 | <kbd>M-p p u</kbd> | `spotify-user-playlists`     | Show playlists for the given user |
 | <kbd>M-p p c</kbd> | `spotify-create-playlist`    | Create a new playlist             |
 | <kbd>M-p t s</kbd> | `spotify-track-search`       | Search for tracks                 |
+| <kbd>M-p v u</kbd> | `spotify-volume-up`          | Increase the volume               |
+| <kbd>M-p v d</kbd> | `spotify-volume-down`        | Decrease the volume               |
+
+The volume controls only work with the Spotify Connect transport. In order to use them, set the transport in your init file as follows:
+
+````el
+(setq spotify-transport 'connect)
+````
+
 
 The current song being played by the Spotify client is displayed in the mode
 line along with the player status (playing, paused). The interval in which the

--- a/README.md
+++ b/README.md
@@ -74,21 +74,22 @@ Finally, scroll to the end of the page and hit **Save**.
 Whenever you enable the `spotify-remote-mode` minor mode you get the following
 key bindings:
 
-| Key                | Function                     | Description                                |
-|:-------------------|:-----------------------------|:-------------------------------------------|
-| <kbd>M-p M-s</kbd> | `spotify-toggle-shuffle`     | Turn shuffle on/off [1]                    |
-| <kbd>M-p M-r</kbd> | `spotify-toggle-repeat`      | Turn repeat on/off [1]                     |
-| <kbd>M-p M-p</kbd> | `spotify-toggle-play`        | Play/pause                                 |
-| <kbd>M-p M-f</kbd> | `spotify-next-track`         | Next track                                 |
-| <kbd>M-p M-b</kbd> | `spotify-previous-track`     | Previous track                             |
-| <kbd>M-p p m</kbd> | `spotify-my-playlists`       | Show your playlists                        |
-| <kbd>M-p p f</kbd> | `spotify-featured-playlists` | Show the featured playlists                |
-| <kbd>M-p p s</kbd> | `spotify-playlist-search`    | Search for playlists                       |
-| <kbd>M-p p u</kbd> | `spotify-user-playlists`     | Show playlists for the given user          |
-| <kbd>M-p p c</kbd> | `spotify-create-playlist`    | Create a new playlist                      |
-| <kbd>M-p t s</kbd> | `spotify-track-search`       | Search for tracks                          |
-| <kbd>M-p v u</kbd> | `spotify-volume-up`          | Increase the volume (Spotify connect only) |
-| <kbd>M-p v d</kbd> | `spotify-volume-down`        | Decrease the volume (Spotify connect only) |
+| Key                | Function                     | Description                                     |
+|:-------------------|:-----------------------------|:------------------------------------------------|
+| <kbd>M-p M-s</kbd> | `spotify-toggle-shuffle`     | Turn shuffle on/off [1]                         |
+| <kbd>M-p M-r</kbd> | `spotify-toggle-repeat`      | Turn repeat on/off [1]                          |
+| <kbd>M-p M-p</kbd> | `spotify-toggle-play`        | Play/pause                                      |
+| <kbd>M-p M-f</kbd> | `spotify-next-track`         | Next track                                      |
+| <kbd>M-p M-b</kbd> | `spotify-previous-track`     | Previous track                                  |
+| <kbd>M-p p m</kbd> | `spotify-my-playlists`       | Show your playlists                             |
+| <kbd>M-p p f</kbd> | `spotify-featured-playlists` | Show the featured playlists                     |
+| <kbd>M-p p s</kbd> | `spotify-playlist-search`    | Search for playlists                            |
+| <kbd>M-p p u</kbd> | `spotify-user-playlists`     | Show playlists for the given user               |
+| <kbd>M-p p c</kbd> | `spotify-create-playlist`    | Create a new playlist                           |
+| <kbd>M-p t s</kbd> | `spotify-track-search`       | Search for tracks                               |
+| <kbd>M-p v u</kbd> | `spotify-volume-up`          | Increase the volume [2]                         |
+| <kbd>M-p v d</kbd> | `spotify-volume-down`        | Decrease the volume [2]                         |
+| <kbd>M-p M-d</kbd> | `spotify-select-device`      | Select a playback device [2]                    |
 
 
 The current song being played by the Spotify client is displayed in the mode
@@ -101,7 +102,8 @@ mode line is updated can be configured via the
 (setq spotify-mode-line-refresh-interval 1)
 ````
 
-[1] No proper support for this in D-Bus implementation for GNU/Linux
+[1] No proper support for this in D-Bus implementation for GNU/Linux  
+[2] This feature uses Spotify Connect and requires a premium subscription
 
 #### Customizing The Mode Line
 

--- a/README.md
+++ b/README.md
@@ -37,14 +37,17 @@ disk, add that directory in the `load-path`, and require the `spotify` module:
 ;; Settings
 (setq spotify-oauth2-client-secret "<spotify-app-client-secret>")
 (setq spotify-oauth2-client-id "<spotify-app-client-id>")
-(setq spotify-transport 'connect)
 ````
 
 In order to get the the client ID and client secret, you need to create
 [a Spotify app](https://developer.spotify.com/my-applications), specifying
 <http://localhost:8591/> as the redirect URI.
 
-To use the "Spotify Connect" transport (in order to control players across the network and have the ability to control volume), set `spotify-transport` to `'connect`. This feature requires a Spotify premium subscription. Otherwise set it to `'apple` (Mac OS) or `'dbus` (GNU Linux).
+To use the "Spotify Connect" transport (in order to control players across the network and have the ability to control volume), set `spotify-transport` to `'connect` as follows. This feature requires a Spotify premium subscription.
+
+````el
+(setq spotify-transport 'connect)
+````
 
 ### Creating The Spotify App
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,14 @@ disk, add that directory in the `load-path`, and require the `spotify` module:
 ;; Settings
 (setq spotify-oauth2-client-secret "<spotify-app-client-secret>")
 (setq spotify-oauth2-client-id "<spotify-app-client-id>")
+(setq spotify-transport 'connect)
 ````
 
 In order to get the the client ID and client secret, you need to create
 [a Spotify app](https://developer.spotify.com/my-applications), specifying
 <http://localhost:8591/> as the redirect URI.
+
+To use the "Spotify Connect" transport (in order to control players across the network and have the ability to control volume), set `spotify-transport` to `'connect`. This feature requires a Spotify premium subscription. Otherwise set it to `'apple` (Mac OS) or `'dbus` (GNU Linux).
 
 ### Creating The Spotify App
 
@@ -68,27 +71,21 @@ Finally, scroll to the end of the page and hit **Save**.
 Whenever you enable the `spotify-remote-mode` minor mode you get the following
 key bindings:
 
-| Key                | Function                     | Description                       |
-|:-------------------|:-----------------------------|:----------------------------------|
-| <kbd>M-p M-s</kbd> | `spotify-toggle-shuffle`     | Turn shuffle on/off [1]           |
-| <kbd>M-p M-r</kbd> | `spotify-toggle-repeat`      | Turn repeat on/off [1]            |
-| <kbd>M-p M-p</kbd> | `spotify-toggle-play`        | Play/pause                        |
-| <kbd>M-p M-f</kbd> | `spotify-next-track`         | Next track                        |
-| <kbd>M-p M-b</kbd> | `spotify-previous-track`     | Previous track                    |
-| <kbd>M-p p m</kbd> | `spotify-my-playlists`       | Show your playlists               |
-| <kbd>M-p p f</kbd> | `spotify-featured-playlists` | Show the featured playlists       |
-| <kbd>M-p p s</kbd> | `spotify-playlist-search`    | Search for playlists              |
-| <kbd>M-p p u</kbd> | `spotify-user-playlists`     | Show playlists for the given user |
-| <kbd>M-p p c</kbd> | `spotify-create-playlist`    | Create a new playlist             |
-| <kbd>M-p t s</kbd> | `spotify-track-search`       | Search for tracks                 |
-| <kbd>M-p v u</kbd> | `spotify-volume-up`          | Increase the volume               |
-| <kbd>M-p v d</kbd> | `spotify-volume-down`        | Decrease the volume               |
-
-The volume controls only work with the Spotify Connect transport. In order to use them, set the transport in your init file as follows:
-
-````el
-(setq spotify-transport 'connect)
-````
+| Key                | Function                     | Description                                |
+|:-------------------|:-----------------------------|:-------------------------------------------|
+| <kbd>M-p M-s</kbd> | `spotify-toggle-shuffle`     | Turn shuffle on/off [1]                    |
+| <kbd>M-p M-r</kbd> | `spotify-toggle-repeat`      | Turn repeat on/off [1]                     |
+| <kbd>M-p M-p</kbd> | `spotify-toggle-play`        | Play/pause                                 |
+| <kbd>M-p M-f</kbd> | `spotify-next-track`         | Next track                                 |
+| <kbd>M-p M-b</kbd> | `spotify-previous-track`     | Previous track                             |
+| <kbd>M-p p m</kbd> | `spotify-my-playlists`       | Show your playlists                        |
+| <kbd>M-p p f</kbd> | `spotify-featured-playlists` | Show the featured playlists                |
+| <kbd>M-p p s</kbd> | `spotify-playlist-search`    | Search for playlists                       |
+| <kbd>M-p p u</kbd> | `spotify-user-playlists`     | Show playlists for the given user          |
+| <kbd>M-p p c</kbd> | `spotify-create-playlist`    | Create a new playlist                      |
+| <kbd>M-p t s</kbd> | `spotify-track-search`       | Search for tracks                          |
+| <kbd>M-p v u</kbd> | `spotify-volume-up`          | Increase the volume (Spotify connect only) |
+| <kbd>M-p v d</kbd> | `spotify-volume-down`        | Decrease the volume (Spotify connect only) |
 
 
 The current song being played by the Spotify client is displayed in the mode

--- a/oauth2.el
+++ b/oauth2.el
@@ -228,7 +228,8 @@ TOKEN can be obtained with `oauth2-auth'."
           (url-request-data request-data)
           (url-request-extra-headers request-extra-headers))
       (url-retrieve-synchronously
-       (oauth2-url-append-access-token token url)))))
+       (oauth2-url-append-access-token token url)
+			 t))))
 
 ;;;###autoload
 (defun oauth2-url-retrieve (token url callback &optional

--- a/spotify-api.el
+++ b/spotify-api.el
@@ -385,6 +385,27 @@ If no args, resume playing current track.  Otherwise, play URI in CONTEXT, if sp
        "")
     (end-of-file t)))
 
+(defun spotify-api-repeat (state)
+  "Set repeat of current track to STATE."
+  (condition-case err
+      (spotify-api-call
+       "PUT"
+       (concat "/me/player/repeat?"
+               (url-build-query-string `((state ,state))
+                                       nil t))
+       "")
+    (end-of-file t)))
 
+
+(defun spotify-api-shuffle (state)
+  "Set repeat of current track to STATE."
+  (condition-case err
+      (spotify-api-call
+       "PUT"
+       (concat "/me/player/shuffle?"
+               (url-build-query-string `((state ,state))
+                                       nil t))
+       "")
+    (end-of-file t)))
 
 (provide 'spotify-api)

--- a/spotify-api.el
+++ b/spotify-api.el
@@ -235,9 +235,9 @@ depending on the `type' argument."
 (defun spotify-api-album-get-tracks (album-id)
   "Get list of track ids for given album."
   (mapcar 'spotify-get-item-id (spotify-get-items (spotify-api-call
-						   "GET"
-						   (format "/albums/%s/tracks"
-							   (url-hexify-string album-id))))))
+               "GET"
+               (format "/albums/%s/tracks"
+                 (url-hexify-string album-id))))))
 
 (defun spotify-api-playlist-add-track (user-id playlist-id track-id)
   "Add single track to playlist"
@@ -310,9 +310,18 @@ which must be a number between 0 and 100."
             (make-string (- 10 num-bars) ?-))))
 
 (defun spotify-api-device-list ()
-	"Retrieve the list of devices available for use with Spotify Connect."
-	(spotify-api-call
-	 "GET"
-	 "/me/player/devices"))
+  "Retrieve the list of devices available for use with Spotify Connect."
+  (spotify-api-call
+   "GET"
+   "/me/player/devices"))
+
+(defun spotify-api-transfer-player (device-id)
+  "Transfer playback to DEVICE-ID and determine if it should start playing."
+  (condition-case err
+      (spotify-api-call
+       "PUT"
+       "/me/player"
+       (format "{\"device_ids\":[\"%s\"]}" device-id))
+    (end-of-file t)))
 
 (provide 'spotify-api)

--- a/spotify-api.el
+++ b/spotify-api.el
@@ -344,4 +344,47 @@ which must be a number between 0 and 100."
        "/me/player")
     (end-of-file nil)))
 
+(defun spotify-api-play (&optional uri context)
+  "Play a track.
+If no args, resume playing current track.  Otherwise, play URI in CONTEXT, if specified."
+  (condition-case err
+      (spotify-api-call
+       "PUT"
+       "/me/player/play"
+       (concat
+        "{"
+        (when uri (format "\"uris\":[\"%s\"]," uri))
+        (when context (format "\"context_uri\":\"%s\"" context))
+        "}"))
+    (end-of-file t)))
+
+(defun spotify-api-pause ()
+  "Pause the currently playing track."
+  (condition-case err
+      (spotify-api-call
+       "PUT"
+       "/me/player/pause"
+       "")
+    (end-of-file t)))
+
+(defun spotify-api-next ()
+  "Skip to the next track."
+  (condition-case err
+      (spotify-api-call
+       "POST"
+       "/me/player/next"
+       "")
+    (end-of-file t)))
+
+(defun spotify-api-previous ()
+  "Skip to the previous track."
+  (condition-case err
+      (spotify-api-call
+       "POST"
+       "/me/player/previous"
+       "")
+    (end-of-file t)))
+
+
+
 (provide 'spotify-api)

--- a/spotify-api.el
+++ b/spotify-api.el
@@ -324,4 +324,24 @@ which must be a number between 0 and 100."
        (format "{\"device_ids\":[\"%s\"]}" device-id))
     (end-of-file t)))
 
+(defun spotify-api-set-volume (device-id percentage)
+  "Set the volume level to PERCENTAGE of max for DEVICE-ID."
+  (condition-case err
+      (spotify-api-call
+       "PUT"
+       (concat "/me/player/volume?"
+               (url-build-query-string `((volume_percent     ,percentage)
+                                         (device_id          ,device-id))
+                                       nil t))
+       "")
+    (end-of-file t)))
+
+(defun spotify-api-get-player-status ()
+  "Get the Spotify Connect status of the currently active player."
+  (condition-case err
+      (spotify-api-call
+       "GET"
+       "/me/player")
+    (end-of-file nil)))
+
 (provide 'spotify-api)

--- a/spotify-api.el
+++ b/spotify-api.el
@@ -309,4 +309,10 @@ which must be a number between 0 and 100."
     (concat (make-string num-bars ?X)
             (make-string (- 10 num-bars) ?-))))
 
+(defun spotify-api-device-list ()
+	"Retrieve the list of devices available for use with Spotify Connect."
+	(spotify-api-call
+	 "GET"
+	 "/me/player/devices"))
+
 (provide 'spotify-api)

--- a/spotify-connect.el
+++ b/spotify-connect.el
@@ -32,15 +32,14 @@ Returns a JSON string in the format:
                   (format "\"track_number\":%d," (gethash 'track_number track))
                   (format "\"name\":\"%s\"," (gethash 'name track))
                   (format "\"player_state\":\"%s\","
-                          (if (gethash 'is_playing status) "playing", "paused"))
+                          (if (eq (gethash 'is_playing status) :json-false) "paused" "playing"))
                   (format "\"player_shuffling\":%s,"
                           (if (not (eq (gethash 'shuffle_state status) :json-false))
                               "true" "false"))
                   (format "\"player_repeating\":%s"
                           (if (string= (gethash 'repeat_state status) "off") "false" "true"))
                   "}"))))
-    (when status
-      (spotify-replace-mode-line-flags json))))
+    (spotify-replace-mode-line-flags json)))
 
 (defun spotify-connect-get-device-id (player-status)
   "Get the id if from PLAYER-STATUS of the currently playing device, if any."

--- a/spotify-connect.el
+++ b/spotify-connect.el
@@ -47,6 +47,30 @@ Returns a JSON string in the format:
   (if player-status
       (gethash 'id (gethash 'device player-status))))
 
+(defun spotify-connect-player-play-track (uri &optional context)
+  "Play a track URI via Spotify Connect in an optional CONTEXT."
+  (spotify-api-play uri context))
+
+(defun spotify-connect-player-pause ()
+  "Pause the currently playing track."
+  (spotify-api-pause))
+
+(defun spotify-connect-player-toggle-play ()
+  "Toggle playing status of current track."
+  (let ((player-status (spotify-api-get-player-status)))
+    (if player-status
+        (if (not (eq (gethash 'is_playing player-status) :json-false))
+            (spotify-api-pause)
+          (spotify-api-play)))))
+
+(defun spotify-connect-player-next-track ()
+  "Skip to the next track."
+  (spotify-api-next))
+
+(defun spotify-connect-player-previous-track ()
+  "Skip to the previous track."
+  (spotify-api-previous))
+
 (defun spotify-connect-get-volume (player-status)
   "Get the volume from PLAYER-STATUS of the currently playing device, if any."
   (if player-status

--- a/spotify-connect.el
+++ b/spotify-connect.el
@@ -23,18 +23,24 @@ Returns a JSON string in the format:
   \"player_repeating\": \"context\"
 }"
   (let* ((status (spotify-api-get-player-status))
-         (track (gethash 'item status)))
-    (spotify-replace-mode-line-flags
-		 (concat "{"
-             (format "\"artist\":\"%s\"," (gethash 'name (car (gethash 'artists track))))
-             (format "\"duration\": %d," (gethash 'duration_ms track))
-             (format "\"track_number\":%d," (gethash 'track_number track))
-             (format "\"name\":\"%s\"," (gethash 'name track))
-             (format "\"player_state\":\"%s\","
-                     (if (gethash 'is_playing status) "playing", "paused"))
-             (format "\"player_shuffling\":\"%s\"," (gethash 'shuffle_state status))
-             (format "\"player_repeating\":\"%s\"" (gethash 'repeat_state status))
-             "}"))))
+         (track (when status (gethash 'item status)))
+         (json (when status
+                 (concat
+                  "{"
+                  (format "\"artist\":\"%s\"," (gethash 'name (car (gethash 'artists track))))
+                  (format "\"duration\": %d," (gethash 'duration_ms track))
+                  (format "\"track_number\":%d," (gethash 'track_number track))
+                  (format "\"name\":\"%s\"," (gethash 'name track))
+                  (format "\"player_state\":\"%s\","
+                          (if (gethash 'is_playing status) "playing", "paused"))
+                  (format "\"player_shuffling\":%s,"
+                          (if (not (eq (gethash 'shuffle_state status) :json-false))
+                              "true" "false"))
+                  (format "\"player_repeating\":%s"
+                          (if (string= (gethash 'repeat_state status) "off") "false" "true"))
+                  "}"))))
+    (when status
+      (spotify-replace-mode-line-flags json))))
 
 (defun spotify-connect-get-device-id (player-status)
   "Get the id if from PLAYER-STATUS of the currently playing device, if any."

--- a/spotify-connect.el
+++ b/spotify-connect.el
@@ -11,8 +11,30 @@
 (require 'spotify-api)
 
 (defun spotify-connect-player-status ()
-  "Get the player status of the currently playing device, if any."
-  (spotify-api-get-player-status))
+  "Get the player status of the currently playing device, if any.
+Returns a JSON string in the format:
+{
+  \"artist\": \"Aesop Rock\",
+  \"duration\": 265333,
+  \"track_number\": 9,
+  \"name\":  \"Shrunk\",
+  \"player_state\": \"playing\",
+  \"player_shuffling\": \"t\",
+  \"player_repeating\": \"context\"
+}"
+  (let* ((status (spotify-api-get-player-status))
+         (track (gethash 'item status)))
+    (spotify-replace-mode-line-flags
+		 (concat "{"
+             (format "\"artist\":\"%s\"," (gethash 'name (car (gethash 'artists track))))
+             (format "\"duration\": %d," (gethash 'duration_ms track))
+             (format "\"track_number\":%d," (gethash 'track_number track))
+             (format "\"name\":\"%s\"," (gethash 'name track))
+             (format "\"player_state\":\"%s\","
+                     (if (gethash 'is_playing status) "playing", "paused"))
+             (format "\"player_shuffling\":\"%s\"," (gethash 'shuffle_state status))
+             (format "\"player_repeating\":\"%s\"" (gethash 'repeat_state status))
+             "}"))))
 
 (defun spotify-connect-get-device-id (player-status)
   "Get the id if from PLAYER-STATUS of the currently playing device, if any."

--- a/spotify-connect.el
+++ b/spotify-connect.el
@@ -1,0 +1,45 @@
+;;; package --- Summary
+
+;;; Commentary:
+
+;; spotify-connect.el --- Spotify.el transport for the Spotify Connect API
+
+;; Copyright (C) 2019 Jason Dufair
+
+;;; Code:
+
+(require 'spotify-api)
+
+(defun spotify-connect-player-status ()
+  "Get the player status of the currently playing device, if any."
+  (spotify-api-get-player-status))
+
+(defun spotify-connect-get-device-id (player-status)
+  "Get the id if from PLAYER-STATUS of the currently playing device, if any."
+  (if player-status
+      (gethash 'id (gethash 'device player-status))))
+
+(defun spotify-connect-get-volume (player-status)
+  "Get the volume from PLAYER-STATUS of the currently playing device, if any."
+  (if player-status
+      (gethash 'volume_percent (gethash 'device player-status))))
+
+(defun spotify-connect-volume-up ()
+  "Turn up the volume on the actively playing device."
+  (let ((player-status (spotify-api-get-player-status)))
+    (spotify-api-set-volume
+     (spotify-connect-get-device-id player-status)
+     (min (+ (spotify-connect-get-volume player-status) 10) 100)))
+  (message "volume increased"))
+
+(defun spotify-connect-volume-down ()
+  "Turn down the volume (for what?) on the actively playing device."
+  (let ((player-status (spotify-api-get-player-status)))
+    (spotify-api-set-volume
+     (spotify-connect-get-device-id player-status)
+     (max (- (spotify-connect-get-volume player-status) 10) 0)))
+  (message "volume decreased"))
+
+(provide 'spotify-connect)
+
+;;; spotify-connect.el ends here

--- a/spotify-connect.el
+++ b/spotify-connect.el
@@ -79,18 +79,63 @@ Returns a JSON string in the format:
 (defun spotify-connect-volume-up ()
   "Turn up the volume on the actively playing device."
   (let ((player-status (spotify-api-get-player-status)))
-    (spotify-api-set-volume
-     (spotify-connect-get-device-id player-status)
-     (min (+ (spotify-connect-get-volume player-status) 10) 100)))
+    (if player-status
+        (spotify-api-set-volume
+         (spotify-connect-get-device-id player-status)
+         (min (+ (spotify-connect-get-volume player-status) 10) 100))))
   (message "volume increased"))
 
 (defun spotify-connect-volume-down ()
   "Turn down the volume (for what?) on the actively playing device."
   (let ((player-status (spotify-api-get-player-status)))
-    (spotify-api-set-volume
-     (spotify-connect-get-device-id player-status)
-     (max (- (spotify-connect-get-volume player-status) 10) 0)))
+    (if player-status
+        (spotify-api-set-volume
+         (spotify-connect-get-device-id player-status)
+         (max (- (spotify-connect-get-volume player-status) 10) 0))))
   (message "volume decreased"))
+
+(defun spotify-connect-is-shuffling-supported ()
+  "Shuffling is supported on Spotify Connect."
+  t)
+
+(defun spotify-connect-is-repeating-supported ()
+  "Repeating is supported Spotify Connect."
+  t)
+
+(defun spotify-connect-toggle-repeat ()
+  "Toggle repeat for the current track."
+  (let ((player-status (spotify-api-get-player-status)))
+    (if player-status
+        (spotify-api-repeat
+         (if (spotify--is-repeating player-status) "off" "context")))))
+
+(defun spotify-connect-toggle-shuffle ()
+  "Toggle shuffle for the current track."
+  (let ((player-status (spotify-api-get-player-status)))
+    (if player-status
+        (spotify-api-shuffle
+         (if (spotify--is-shuffling player-status) "false" "true")))))
+
+(defun spotify-connect-is-repeating ()
+  "Answer whether the current device is set to repeat."
+  (let ((player-status (spotify-api-get-player-status)))
+    (and player-status
+         (spotify--is-repeating player-status))))
+
+(defun spotify-connect-is-shuffling ()
+  "Answer whether the current device is set to shuffle."
+  (let ((player-status (spotify-api-get-player-status)))
+    (spotify--is-shuffling player-status)))
+
+(defun spotify--is-shuffling (player-status)
+  "Business logic for shuffling state of PLAYER-STATUS."
+  (and player-status
+         (not (eq (gethash 'shuffle_state player-status) :json-false))))
+
+(defun spotify--is-repeating (player-status)
+  "Business logic for repeat state of PLAYER-STATUS."
+  (string= (gethash 'repeat_state player-status) "context"))
+
 
 (provide 'spotify-connect)
 

--- a/spotify-controller.el
+++ b/spotify-controller.el
@@ -26,7 +26,7 @@
   "Evaluate THEN form if Emacs is running in OS X."
   `(if-darwin ,then nil))
 
-(defcustom spotify-transport nil
+(defcustom spotify-transport (if-gnu-linux 'dbus 'apple)
   "How the commands should be sent to Spotify process.  Defaults for `dbus' for GNU/Linux, `apple' otherwise."
   :type '(choice (symbol :tag "AppleScript" apple)
                  (symbol :tag "D-Bus" dbus)

--- a/spotify-controller.el
+++ b/spotify-controller.el
@@ -1,67 +1,87 @@
-;; spotify-controller.el --- Generic player controller interface for Spotify.el
+;;; package --- Summary
+
+;;; Commentary:
+
+;;; spotify-controller.el --- Generic player controller interface for Spotify.el
 
 ;; Copyright (C) 2014-2016 Daniel Fernandes Martins
 
-;; Code:
+;;; Code:
+
+(require 'spotify-remote)
 
 (defmacro if-gnu-linux (then else)
-  "Evaluates `then' form if Emacs is running in GNU/Linux, otherwise evaluates
-`else' form."
+  "Evaluate THEN form if Emacs is running in GNU/Linux, otherwise evaluate ELSE form."
   `(if (eq system-type 'gnu/linux) ,then ,else))
 
 (defmacro when-gnu-linux (then)
-  "Evaluates `then' form if Emacs is running in GNU/Linux."
+  "Evaluate THEN form if Emacs is running in GNU/Linux."
   `(if-gnu-linux ,then nil))
 
 (defmacro if-darwin (then else)
-  "Evaluates `then' form if Emacs is running in OS X, otherwise evaluates
-`else' form."
+  "Evaluate THEN form if Emacs is running in OS X, otherwise evaluate ELSE form."
   `(if (eq system-type 'darwin) ,then ,else))
 
 (defmacro when-darwin (then)
-  "Evaluates `then' form if Emacs is running in OS X."
+  "Evaluate THEN form if Emacs is running in OS X."
   `(if-darwin ,then nil))
 
 (defcustom spotify-transport (if-gnu-linux 'dbus 'apple)
-  "How the commands should be sent to Spotify process. Defaults for `dbus' for
-GNU/Linux, `apple' otherwise."
+  "How the commands should be sent to Spotify process.  Defaults for `dbus' for GNU/Linux, `apple' otherwise."
   :type '(choice (symbol :tag "AppleScript" apple)
-                 (symbol :tag "D-Bus" dbus)))
+                 (symbol :tag "D-Bus" dbus)
+                 (symbol :tag "Connect" connect))
+  :group 'spotify)
 
 ;; TODO: No modeline support for linux just yet
 (defcustom spotify-mode-line-refresh-interval 1
-  "The interval, in seconds, that the mode line must be updated. Set to 0 to
-   disable this feature."
-  :type 'integer)
+  "The interval, in seconds, that the mode line must be updated.  Set to 0 to disable this feature."
+  :type 'integer
+  :group 'spotify)
 
 (defcustom spotify-mode-line-truncate-length 15
-  "The maximum number of characters to truncated fields in
-`spotify-mode-line-format'.")
+  "The maximum number of characters to truncated fields in `spotify-mode-line-format'."
+  :type 'integer
+  :group 'spotify)
 
 (defcustom spotify-mode-line-playing-text "Playing"
-  "Text to be displayed when Spotify is playing")
+  "Text to be displayed when Spotify is playing."
+  :type 'string
+  :group 'spotify)
 
 (defcustom spotify-mode-line-paused-text "Paused"
-  "Text to be displayed when Spotify is paused")
+  "Text to be displayed when Spotify is paused."
+  :type 'string
+  :group 'spotify)
 
 (defcustom spotify-mode-line-stopped-text "Stopped"
-  "Text to be displayed when Spotify is stopped")
+  "Text to be displayed when Spotify is stopped."
+  :type 'string
+  :group 'spotify)
 
 (defcustom spotify-mode-line-repeating-text "R"
-  "Text to be displayed when repeat is enabled")
+  "Text to be displayed when repeat is enabled."
+  :type 'string
+  :group 'spotify)
 
 (defcustom spotify-mode-line-not-repeating-text "-"
-  "Text to be displayed when repeat is disabled")
+  "Text to be displayed when repeat is disabled."
+  :type 'string
+  :group 'spotify)
 
 (defcustom spotify-mode-line-shuffling-text "S"
-  "Text to be displayed when shuffling is enabled")
+  "Text to be displayed when shuffling is enabled."
+  :type 'string
+  :group 'spotify)
 
 (defcustom spotify-mode-line-not-shuffling-text "-"
-  "Text to be displayed when shuffling is disabled")
+  "Text to be displayed when shuffling is disabled."
+  :type 'string
+  :group 'spotify)
 
 (defcustom spotify-mode-line-format "[%p: %a - %t ◷ %l %r%s]"
-  "Format used to display the current Spotify client player status. The
-following placeholders are supported:
+  "Format used to display the current Spotify client player status.
+The following placeholders are supported:
 
 * %a - Artist name (truncated)
 * %t - Track name (truncated)
@@ -69,38 +89,42 @@ following placeholders are supported:
 * %l - Track duration, in minutes (i.e. 01:35)
 * %p - Player status indicator for 'playing', 'paused', and 'stopped' states
 * %s - Player shuffling status indicator
-* %r - Player repeating status indicator")
+* %r - Player repeating status indicator"
+  :type 'string
+  :group 'spotify)
 
 (defvar spotify-timer nil)
+(defvar spotify-mode-line-stale)
 
-;; simple facility to emulate multimethods
 (defun spotify-apply (suffix &rest args)
+  "Simple facility to emulate multimethods.
+Apply SUFFIX to spotify-prefixed functions, applying ARGS."
   (let ((func-name (format "spotify-%s-%s" spotify-transport suffix)))
     (apply (intern func-name) args)))
 
 (defun spotify-mode-line-playing-indicator (str)
-  "Returns the value of the player state variable corresponding to the player's
-current state (playing, stopped, paused)."
+  "Return the value of the player state variable.
+This value corresponding to the player's current state in STR."
   (cond ((string= "playing" str) spotify-mode-line-playing-text)
         ((string= "stopped" str) spotify-mode-line-stopped-text)
         ((string= "paused" str) spotify-mode-line-paused-text)))
 
 (defun spotify-mode-line-shuffling-indicator (shuffling)
-  "Returns the value of the shuffling state variable corresponding to the
-current shuffling state."
+  "Return the value of the shuffling state variable.
+This value corresponds to the current SHUFFLING state."
   (if (eq shuffling t)
       spotify-mode-line-shuffling-text
     spotify-mode-line-not-shuffling-text))
 
 (defun spotify-mode-line-repeating-indicator (repeating)
-  "Returns the value of the repeating state variable corresponding to the
-current repeating state."
+  "Return the value of the repeating state variable.
+This corresponds to the current REPEATING state."
   (if (eq repeating t)
       spotify-mode-line-repeating-text
     spotify-mode-line-not-repeating-text))
 
 (defun spotify-replace-mode-line-flags (metadata)
-  "Compose the playing status string to be displayed in the mode-line."
+  "Compose the playing status string to be displayed in the mode-line from METADATA."
   (let* ((mode-line spotify-mode-line-format)
          (duration-format "%m:%02s")
          (json-object-type 'hash-table)
@@ -121,8 +145,7 @@ current repeating state."
         (spotify-update-mode-line mode-line)))))
 
 (defun spotify-start-mode-line-timer ()
-  "Starts the timer that updates the mode line according to the Spotify
-   player status."
+  "Start the timer that will update the mode line according to the Spotify player status."
   (spotify-stop-mode-line-timer)
   (when (> spotify-mode-line-refresh-interval 0)
     (let ((first-run (format "%d sec" spotify-mode-line-refresh-interval))
@@ -131,18 +154,18 @@ current repeating state."
             (run-at-time first-run interval 'spotify-refresh-mode-line)))))
 
 (defun spotify-stop-mode-line-timer ()
-  "Stops the timer that updates the mode line."
+  "Stop the timer that is updating the mode line."
   (when (and (boundp 'spotify-timer) (timerp spotify-timer))
     (cancel-timer spotify-timer))
   (spotify-player-status))
 
 (defun spotify-player-status ()
-  "Updates the mode line to display the current Spotify player status."
+  "Update the mode line to display the current Spotify player status."
   (interactive)
   (spotify-apply "player-status"))
 
-(defun spotify-refresh-mode-line (&rest args)
-  "Starts the player status process in order to update the mode line."
+(defun spotify-refresh-mode-line ()
+  "Start the player status process in order to update the mode line."
   (spotify-apply "player-status")
   (when spotify-mode-line-stale
     (setq spotify-mode-line-stale nil)
@@ -154,7 +177,7 @@ current repeating state."
   (spotify-apply "player-play-track" uri nil))
 
 (defun spotify-play-track (track &optional context)
-  "Sends a `play' command to Spotify process passing a context id."
+  "Sends a `play' command to Spotify process with TRACK passing a CONTEXT id."
   (interactive)
   (spotify-apply "player-play-track"
                  (when track (spotify-get-item-uri track))
@@ -185,13 +208,18 @@ current repeating state."
   (interactive)
   (spotify-apply "player-pause"))
 
+(defun spotify-device-volume-up ()
+  "Increase the volume by 10 percent for the active device."
+  (interactive)
+  (spotify-apply "set-volume"))
+
 (defun spotify-is-repeating-supported()
-  "Returns whether toggling repeat is supported."
+  "Return whether toggling repeat is supported."
   (interactive)
   (spotify-apply "is-repeating-supported"))
 
 (defun spotify-is-shuffling-supported()
-  "Returns whether toggling shuffle is supported."
+  "Return whether toggling shuffle is supported."
   (interactive)
   (spotify-apply "is-shuffling-supported"))
 
@@ -214,3 +242,5 @@ current repeating state."
   (spotify-apply "is-shuffling"))
 
 (provide 'spotify-controller)
+
+;;; spotify-controller.el ends here

--- a/spotify-controller.el
+++ b/spotify-controller.el
@@ -208,10 +208,15 @@ This corresponds to the current REPEATING state."
   (interactive)
   (spotify-apply "player-pause"))
 
-(defun spotify-device-volume-up ()
-  "Increase the volume by 10 percent for the active device."
+(defun spotify-volume-up ()
+  "Increase the volume for the active device."
   (interactive)
-  (spotify-apply "set-volume"))
+  (spotify-apply "volume-up"))
+
+(defun spotify-volume-down ()
+  "Increase the volume for the active device."
+  (interactive)
+  (spotify-apply "volume-down"))
 
 (defun spotify-is-repeating-supported()
   "Return whether toggling repeat is supported."

--- a/spotify-controller.el
+++ b/spotify-controller.el
@@ -26,7 +26,7 @@
   "Evaluate THEN form if Emacs is running in OS X."
   `(if-darwin ,then nil))
 
-(defcustom spotify-transport (if-gnu-linux 'dbus 'apple)
+(defcustom spotify-transport nil
   "How the commands should be sent to Spotify process.  Defaults for `dbus' for GNU/Linux, `apple' otherwise."
   :type '(choice (symbol :tag "AppleScript" apple)
                  (symbol :tag "D-Bus" dbus)

--- a/spotify-device-select.el
+++ b/spotify-device-select.el
@@ -10,55 +10,62 @@
 
 (require 'spotify-api)
 
+(defcustom spotify-selected-device-id ""
+  "The id of the device selected for transport."
+  :type 'string)
+
 (defvar spotify-device-select-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map tabulated-list-mode-map)
-    (define-key map (kbd "M-RET") 'spotify-device-select)
-    (define-key map (kbd "g")     'spotify-device-list-reload)
+    (define-key map (kbd "g")     'spotify-device-select-update)
     map)
   "Local keymap for `spotify-device-select-mode' buffers.")
 
 (define-derived-mode spotify-device-select-mode tabulated-list-mode "Device-Select"
   "Major mode for selecting a Spotify Connect device for transport.")
 
-(defun spotify-device-select-update (current-page)
-  "Fetches the CURRENT-PAGE of devices using the device list endpoint."
+(defun spotify-device-select-update ()
+  "Fetches the list of devices using the device list endpoint."
+  (interactive)
   (let* ((json (spotify-api-device-list))
-         (devices (gethash 'devices json)))
+         (devices (gethash 'devices json))
+         (line (string-to-number (format-mode-line "%l"))))
     (if devices
         (progn
-          (spotify-devices-print devices current-page)
+          (spotify-devices-print devices)
+          (goto-char (point-min))
+          (forward-line (1- line))
           (message "device list updated"))
       (message "No more devices"))))
 
-(defun spotify-device-list-reload ()
-  "Reloads the devices for the current device list view."
-  (interactive)
-	(spotify-device-select-update 1))
-
-(defun spotify-devices-print (devices current-page)
-  "Append the given DEVICES the CURRENT-PAGE devices view."
+(defun spotify-devices-print (devices)
+  "Append the given DEVICES to the devices view."
   (let (entries)
     (dolist (device devices)
       (let ((name (spotify-get-device-name device))
-						(is-active (spotify-get-device-is-active device))
-						(is-restricted (spotify-get-device-is-restricted device))
-						(volume (spotify-get-device-volume device)))
-				(unless is-restricted
-					(push (list device
-                    (vector
-                        (cons name
-                           (list 'face 'link
-                                 'follow-link t
-                                 'action `(lambda (_) (message "hello"))
-                                 'help-echo (format "Select %s for transport" name)))
-												(if is-active "🔈" "")
-												(if is-active (number-to-string volume) "")))
-              entries))))
-    (when (eq 1 current-page)
-      (setq-local tabulated-list-entries nil))
+            (is-active (spotify-get-device-is-active device))
+            (is-restricted (spotify-get-device-is-restricted device))
+            (volume (spotify-get-device-volume device))
+            (device-id (spotify-get-device-id device)))
+        (unless is-restricted
+          (push
+           (list device
+                 (vector
+                  (cons name
+                        (list 'face 'link
+                              'follow-link t
+                              'action `(lambda (_)
+                                         (progn
+                                           (setq spotify-selected-device-id ,device-id)
+                                           (spotify-api-transfer-player ,device-id)
+                                           ;; FIXME: figure out how to do this synchronously
+                                           (run-at-time 1 nil #'spotify-device-select-update)))
+                              'help-echo (format "Select %s for transport" name)))
+                  (if is-active "X" "")
+                  (if is-active (number-to-string volume) "")))
+           entries))))
+    (setq-local tabulated-list-entries nil)
     (setq-local tabulated-list-entries (append tabulated-list-entries (nreverse entries)))
-    (setq-local spotify-current-page current-page)
     (spotify-device-set-list-format)
     (tabulated-list-init-header)
     (tabulated-list-print t)))
@@ -71,20 +78,24 @@
                 '("Volume" 8 nil :right-align t))))
 
 (defun spotify-get-device-name (device)
-	"Return the name from the given DEVICE hash."
-	(gethash 'name device))
+  "Return the name from the given DEVICE hash."
+  (gethash 'name device))
 
 (defun spotify-get-device-is-active (device)
-	"Return whether the DEVICE is currently playing content."
+  "Return whether the DEVICE is currently playing content."
   (eq (gethash 'is_active device) t))
 
 (defun spotify-get-device-volume (device)
-	"Return the volume of the DEVICE."
-	(gethash 'volume_percent device))
+  "Return the volume of the DEVICE."
+  (gethash 'volume_percent device))
 
 (defun spotify-get-device-is-restricted (device)
-	"Return whether the DEVICE can receive commands."
-	(eq (gethash 'is_restricted device) t))
+  "Return whether the DEVICE can receive commands."
+  (eq (gethash 'is_restricted device) t))
+
+(defun spotify-get-device-id (device)
+  "Return the unique id of DEVICE."  
+  (gethash 'id device))
 
 (provide 'spotify-device-select)
 

--- a/spotify-device-select.el
+++ b/spotify-device-select.el
@@ -14,8 +14,7 @@
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map tabulated-list-mode-map)
     (define-key map (kbd "M-RET") 'spotify-device-select)
-    (define-key map (kbd "l")     'spotify-playlist-load-more)
-    (define-key map (kbd "g")     'spotify-playlist-reload)
+    (define-key map (kbd "g")     'spotify-device-list-reload)
     map)
   "Local keymap for `spotify-device-select-mode' buffers.")
 
@@ -31,6 +30,11 @@
           (spotify-devices-print devices current-page)
           (message "device list updated"))
       (message "No more devices"))))
+
+(defun spotify-device-list-reload ()
+  "Reloads the devices for the current device list view."
+  (interactive)
+	(spotify-device-select-update 1))
 
 (defun spotify-devices-print (devices current-page)
   "Append the given DEVICES the CURRENT-PAGE devices view."

--- a/spotify-device-select.el
+++ b/spotify-device-select.el
@@ -30,13 +30,12 @@
   (let* ((json (spotify-api-device-list))
          (devices (gethash 'devices json))
          (line (string-to-number (format-mode-line "%l"))))
-    (if devices
+    (when devices
         (progn
           (spotify-devices-print devices)
           (goto-char (point-min))
           (forward-line (1- line))
-          (message "device list updated"))
-      (message "No more devices"))))
+          (message "Device list updated.")))))
 
 (defun spotify-devices-print (devices)
   "Append the given DEVICES to the devices view."
@@ -57,9 +56,10 @@
                               'action `(lambda (_)
                                          (progn
                                            (setq spotify-selected-device-id ,device-id)
-                                           (spotify-api-transfer-player ,device-id)
-                                           ;; FIXME: figure out how to do this synchronously
-                                           (run-at-time 1 nil #'spotify-device-select-update)))
+                                           (spotify-api-transfer-player
+                                            ,device-id
+                                            ,(lambda () (progn (message "switching devices") (spotify-device-select-update)
+                                                          (message "wtf"))))))
                               'help-echo (format "Select %s for transport" name)))
                   (if is-active "X" "")
                   (if is-active (number-to-string volume) "")))

--- a/spotify-device-select.el
+++ b/spotify-device-select.el
@@ -56,10 +56,8 @@
                               'action `(lambda (_)
                                          (progn
                                            (setq spotify-selected-device-id ,device-id)
-                                           (spotify-api-transfer-player
-                                            ,device-id
-                                            ,(lambda () (progn (message "switching devices") (spotify-device-select-update)
-                                                          (message "wtf"))))))
+                                           (spotify-api-transfer-player ,device-id)
+                                           (run-at-time 1 nil #'spotify-device-select-update)))
                               'help-echo (format "Select %s for transport" name)))
                   (if is-active "X" "")
                   (if is-active (number-to-string volume) "")))

--- a/spotify-device-select.el
+++ b/spotify-device-select.el
@@ -22,17 +22,65 @@
 (define-derived-mode spotify-device-select-mode tabulated-list-mode "Device-Select"
   "Major mode for selecting a Spotify Connect device for transport.")
 
-(defun spotify-playlist-search-update (current-page)
+(defun spotify-device-select-update (current-page)
   "Fetches the CURRENT-PAGE of devices using the device list endpoint."
-  (let* ((json (spotify-api-search 'playlist spotify-query current-page))
-         (items (spotify-get-search-playlist-items json)))
-    (if items
+  (let* ((json (spotify-api-device-list))
+         (devices (gethash 'devices json)))
+    (if devices
         (progn
-          (spotify-playlist-search-print items current-page)
-          (message "playlist view updated"))
-      (message "No more playlists"))))
+          (spotify-devices-print devices current-page)
+          (message "device list updated"))
+      (message "No more devices"))))
 
+(defun spotify-devices-print (devices current-page)
+  "Append the given DEVICES the CURRENT-PAGE devices view."
+  (let (entries)
+    (dolist (device devices)
+      (let ((name (spotify-get-device-name device))
+						(is-active (spotify-get-device-is-active device))
+						(is-restricted (spotify-get-device-is-restricted device))
+						(volume (spotify-get-device-volume device)))
+				(unless is-restricted
+					(push (list device
+                    (vector
+                        (cons name
+                           (list 'face 'link
+                                 'follow-link t
+                                 'action `(lambda (_) (message "hello"))
+                                 'help-echo (format "Select %s for transport" name)))
+												(if is-active "🔈" "")
+												(if is-active (number-to-string volume) "")))
+              entries))))
+    (when (eq 1 current-page)
+      (setq-local tabulated-list-entries nil))
+    (setq-local tabulated-list-entries (append tabulated-list-entries (nreverse entries)))
+    (setq-local spotify-current-page current-page)
+    (spotify-device-set-list-format)
+    (tabulated-list-init-header)
+    (tabulated-list-print t)))
 
+(defun spotify-device-set-list-format ()
+  "Configures the column data for the device view."
+  (setq tabulated-list-format
+        (vector `("Device" ,(- (window-width) 18) t)
+                '("Active" 8 t)
+                '("Volume" 8 nil :right-align t))))
+
+(defun spotify-get-device-name (device)
+	"Return the name from the given DEVICE hash."
+	(gethash 'name device))
+
+(defun spotify-get-device-is-active (device)
+	"Return whether the DEVICE is currently playing content."
+  (eq (gethash 'is_active device) t))
+
+(defun spotify-get-device-volume (device)
+	"Return the volume of the DEVICE."
+	(gethash 'volume_percent device))
+
+(defun spotify-get-device-is-restricted (device)
+	"Return whether the DEVICE can receive commands."
+	(eq (gethash 'is_restricted device) t))
 
 (provide 'spotify-device-select)
 

--- a/spotify-device-select.el
+++ b/spotify-device-select.el
@@ -71,8 +71,8 @@
 (defun spotify-device-set-list-format ()
   "Configures the column data for the device view."
   (setq tabulated-list-format
-        (vector `("Device" ,(- (window-width) 18) t)
-                '("Active" 8 t)
+        (vector `("Device" ,(- (window-width) 22) t)
+                '("Active" 12 t)
                 '("Volume" 8 nil :right-align t))))
 
 (defun spotify-get-device-name (device)

--- a/spotify-device-select.el
+++ b/spotify-device-select.el
@@ -1,0 +1,39 @@
+;;; package --- Summary
+
+;;; Commentary:
+
+;; spotify-device-select.el --- Spotify.el device selection major mode
+
+;; Copyright (C) 2019 Jason Dufair
+
+;;; Code:
+
+(require 'spotify-api)
+
+(defvar spotify-device-select-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map tabulated-list-mode-map)
+    (define-key map (kbd "M-RET") 'spotify-device-select)
+    (define-key map (kbd "l")     'spotify-playlist-load-more)
+    (define-key map (kbd "g")     'spotify-playlist-reload)
+    map)
+  "Local keymap for `spotify-device-select-mode' buffers.")
+
+(define-derived-mode spotify-device-select-mode tabulated-list-mode "Device-Select"
+  "Major mode for selecting a Spotify Connect device for transport.")
+
+(defun spotify-playlist-search-update (current-page)
+  "Fetches the CURRENT-PAGE of devices using the device list endpoint."
+  (let* ((json (spotify-api-search 'playlist spotify-query current-page))
+         (items (spotify-get-search-playlist-items json)))
+    (if items
+        (progn
+          (spotify-playlist-search-print items current-page)
+          (message "playlist view updated"))
+      (message "No more playlists"))))
+
+
+
+(provide 'spotify-device-select)
+
+;;; spotify-device-select.el ends here

--- a/spotify-device-select.el
+++ b/spotify-device-select.el
@@ -94,7 +94,7 @@
   (eq (gethash 'is_restricted device) t))
 
 (defun spotify-get-device-id (device)
-  "Return the unique id of DEVICE."  
+  "Return the unique id of DEVICE."
   (gethash 'id device))
 
 (provide 'spotify-device-select)

--- a/spotify-remote.el
+++ b/spotify-remote.el
@@ -34,6 +34,8 @@ See commands \\[spotify-toggle-repeating] and
             (define-key map (kbd "M-p p s") 'spotify-playlist-search)
             (define-key map (kbd "M-p p c") 'spotify-create-playlist)
             (define-key map (kbd "M-p t s") 'spotify-track-search)
+            (define-key map (kbd "M-p v u") 'spotify-volume-up)
+            (define-key map (kbd "M-p v d") 'spotify-volume-down)
             map)
   (let ((s '(:eval (spotify-mode-line-text))))
     (if spotify-remote-mode
@@ -100,6 +102,7 @@ See commands \\[spotify-toggle-repeating] and
 (defun turn-on-spotify-remote-mode ()
   "Turns the `spotify-remote-mode' on in the current buffer."
   (spotify-remote-mode 1))
+
 
 (define-globalized-minor-mode global-spotify-remote-mode
   spotify-remote-mode turn-on-spotify-remote-mode

--- a/spotify-remote.el
+++ b/spotify-remote.el
@@ -36,6 +36,7 @@ See commands \\[spotify-toggle-repeating] and
             (define-key map (kbd "M-p t s") 'spotify-track-search)
             (define-key map (kbd "M-p v u") 'spotify-volume-up)
             (define-key map (kbd "M-p v d") 'spotify-volume-down)
+						(define-key map (kbd "M-p M-d") 'spotify-select-device)
             map)
   (let ((s '(:eval (spotify-mode-line-text))))
     (if spotify-remote-mode

--- a/spotify.el
+++ b/spotify.el
@@ -40,6 +40,7 @@
 
 (when-darwin    (require 'spotify-apple))
 (when-gnu-linux (require 'spotify-dbus))
+(require 'spotify-connect)
 
 (defgroup spotify nil
   "Spotify client."

--- a/spotify.el
+++ b/spotify.el
@@ -116,4 +116,17 @@
   (let ((new-playlist (spotify-api-playlist-create (spotify-current-user-id) name is-public)))
     (message (format "Playlist '%s' created" (spotify-get-item-name new-playlist)))))
 
+;;;###autoload
+(defun spotify-select-device ()
+  "Allows for the selection of a device via Spotify Connect for transport functions."
+  (interactive)
+  (let ((buffer (get-buffer-create "*Devices*")))
+    (with-current-buffer buffer
+      (spotify-select-device-mode)
+      (setq-local spotify-current-page 1)
+      (setq tabulated-list-entries nil)
+      (pop-to-buffer buffer)
+      (spotify-device-list-update 1)
+      buffer)))
+
 (provide 'spotify)

--- a/spotify.el
+++ b/spotify.el
@@ -122,11 +122,11 @@
   (interactive)
   (let ((buffer (get-buffer-create "*Devices*")))
     (with-current-buffer buffer
-      (spotify-select-device-mode)
+      (spotify-device-select-mode)
       (setq-local spotify-current-page 1)
       (setq tabulated-list-entries nil)
       (pop-to-buffer buffer)
-      (spotify-device-list-update 1)
+      (spotify-device-select-update 1)
       buffer)))
 
 (provide 'spotify)

--- a/spotify.el
+++ b/spotify.el
@@ -34,6 +34,7 @@
 (require 'spotify-api)
 (require 'spotify-track-search)
 (require 'spotify-playlist-search)
+(require 'spotify-device-select)
 (require 'spotify-controller)
 (require 'spotify-remote)
 
@@ -126,7 +127,7 @@
       (setq-local spotify-current-page 1)
       (setq tabulated-list-entries nil)
       (pop-to-buffer buffer)
-      (spotify-device-select-update 1)
+      (spotify-device-select-update)
       buffer)))
 
 (provide 'spotify)

--- a/spotify.el
+++ b/spotify.el
@@ -119,15 +119,17 @@
 
 ;;;###autoload
 (defun spotify-select-device ()
-  "Allows for the selection of a device via Spotify Connect for transport functions."
+  "Allow for the selection of a device via Spotify Connect for transport functions."
   (interactive)
-  (let ((buffer (get-buffer-create "*Devices*")))
-    (with-current-buffer buffer
-      (spotify-device-select-mode)
-      (setq-local spotify-current-page 1)
-      (setq tabulated-list-entries nil)
-      (pop-to-buffer buffer)
-      (spotify-device-select-update)
-      buffer)))
+  (if (not (string= (gethash 'product (spotify-current-user)) "premium"))
+      (message "This feature requires a Spotify premium subscription.")
+    (let ((buffer (get-buffer-create "*Devices*")))
+      (with-current-buffer buffer
+        (spotify-device-select-mode)
+        (setq-local spotify-current-page 1)
+        (setq tabulated-list-entries nil)
+        (pop-to-buffer buffer)
+        (spotify-device-select-update)
+        buffer))))
 
 (provide 'spotify)


### PR DESCRIPTION
Hi @danielfm. This implements the ability to redirect playback to any "Spotify Connect" device. I don't know if you want to merge this now, since it's a useful feature as is, or wait. I intend to update the transport/controller logic to send transport commands to either the local Spotify instance or the Spotify Connect device, if selected.