### PR TITLE
Added missing function "play" to two backends.

### DIFF
--- a/spotify-apple.el
+++ b/spotify-apple.el
@@ -101,4 +101,7 @@ end tell
 (defun spotify-apple-player-pause ()
   (spotify-apple-command "pause"))
 
+(defun spotify-apple-player-play ()
+  (spotify-apple-command "play"))
+
 (provide 'spotify-apple)

--- a/spotify-connect.el
+++ b/spotify-connect.el
@@ -68,6 +68,11 @@ Returns a JSON string in the format:
   (spotify-when-device-active
    (spotify-api-pause)))
 
+(defun spotify-connect-player-play ()
+  "Play something probably."
+  (spotify-when-device-active
+   (spotify-api-play)))
+
 (defun spotify-connect-player-toggle-play ()
   "Toggle playing status of current track."
   (spotify-when-device-active


### PR DESCRIPTION
Simple commit to add "play". apple and connect were missing spotify-*-player-play.