### PR TITLE
Remove unused functions

### DIFF
--- a/spotify-apple.el
+++ b/spotify-apple.el
@@ -98,7 +98,4 @@ end tell
 (defun spotify-apple-player-play-track (track-id context-id)
   (spotify-apple-command (format "play track \"%s\" in context \"%s\"" track-id context-id)))
 
-(defun spotify-apple-player-pause ()
-  (spotify-apple-command "pause"))
-
 (provide 'spotify-apple)

--- a/spotify-controller.el
+++ b/spotify-controller.el
@@ -183,11 +183,6 @@ This corresponds to the current REPEATING state."
   (interactive)
   (spotify-apply "player-toggle-play"))
 
-(defun spotify-play ()
-  "Sends a `play' command to Spotify process."
-  (interactive)
-  (spotify-apply "player-play"))
-
 (defun spotify-next-track ()
   "Sends a `next track' command to Spotify process."
   (interactive)
@@ -197,11 +192,6 @@ This corresponds to the current REPEATING state."
   "Sends a `previous track' command to Spotify process."
   (interactive)
   (spotify-apply "player-previous-track"))
-
-(defun spotify-pause ()
-  "Sends a `pause' command to Spotify process."
-  (interactive)
-  (spotify-apply "player-pause"))
 
 (defun spotify-volume-up ()
   "Increase the volume for the active device."

--- a/spotify-dbus.el
+++ b/spotify-dbus.el
@@ -96,10 +96,4 @@
   (when track-id (spotify-dbus-call "Pause"))
   (run-at-time "1 sec" nil 'spotify-dbus-call "OpenUri" (or track-id context-id)))
 
-(defun spotify-dbus-player-play ()
-  (spotify-dbus-call "Play"))
-
-(defun spotify-dbus-player-pause ()
-  (spotify-dbus-call "Pause"))
-
 (provide 'spotify-dbus)


### PR DESCRIPTION
Remove unused functions `spotify-play` and `spotify-pause`, and the corresponding functions from all backends.

Ref: #40