### PR TITLE
Fix customization and documentation for spotify-keymap-prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,7 @@ disk, add that directory in the `load-path`, and require the `spotify` module:
 ;; Settings
 (setq spotify-oauth2-client-secret "<spotify-app-client-secret>")
 (setq spotify-oauth2-client-id "<spotify-app-client-id>")
-(define-key spotify-mode-map (kbd "C-c .") 'spotify-command-map)
 ````
-
-That keymap prefix is just a suggestion, following the conventions suggested for minor modes as
-defined in the Emacs manual [Key Binding
-Conventions](https://www.gnu.org/software/emacs/manual/html_node/elisp/Key-Binding-Conventions.html#Key-Binding-Conventions). Previous
-versions of this package used "M-p"
 
 In order to get the the client ID and client secret, you need to create
 [a Spotify app](https://developer.spotify.com/my-applications), specifying
@@ -80,32 +74,37 @@ Finally, scroll to the end of the page and hit **Save**.
 
 ### Remote Minor Mode
 
-Whenever you enable the `spotify-remote-mode` minor mode you get the following
-key bindings:
+Enabling the `spotify-remote-mode` minor mode gives you convenient keybindings
+under a user defined prefix. Set `spotify-keymap-prefix` before loading
+`spotify.el` or use the customize interface to set it. A suggestion is <kbd>C-c
+.</kbd>, following the conventions suggested for minor modes as defined in the
+Emacs manual [Key Binding
+Conventions](https://www.gnu.org/software/emacs/manual/html_node/elisp/Key-Binding-Conventions.html#Key-Binding-Conventions).
+Previous versions of this package used <kbd>M-p</kbd>.
 
-| Key                  | Function                     | Description                                |
-|:---------------------|:-----------------------------|:-------------------------------------------|
-| <kbd>C-c . M-s</kbd> | `spotify-toggle-shuffle`     | Turn shuffle on/off [1]                    |
-| <kbd>C-c . M-r</kbd> | `spotify-toggle-repeat`      | Turn repeat on/off [1]                     |
-| <kbd>C-c . M-p</kbd> | `spotify-toggle-play`        | Play/pause                                 |
-| <kbd>C-c . M-f</kbd> | `spotify-next-track`         | Next track                                 |
-| <kbd>C-c . M-b</kbd> | `spotify-previous-track`     | Previous track                             |
-| <kbd>C-c . p m</kbd> | `spotify-my-playlists`       | Show your playlists                        |
-| <kbd>C-c . p f</kbd> | `spotify-featured-playlists` | Show the featured playlists                |
-| <kbd>C-c . p s</kbd> | `spotify-playlist-search`    | Search for playlists                       |
-| <kbd>C-c . p u</kbd> | `spotify-user-playlists`     | Show playlists for the given user          |
-| <kbd>C-c . p c</kbd> | `spotify-create-playlist`    | Create a new playlist                      |
-| <kbd>C-c . t r</kbd> | `spotify-recently-played`    | List of recently played tracks             |
-| <kbd>C-c . t s</kbd> | `spotify-track-search`       | Search for tracks                          |
-| <kbd>C-c . v u</kbd> | `spotify-volume-up`          | Increase the volume [2]                    |
-| <kbd>C-c . v d</kbd> | `spotify-volume-down`        | Decrease the volume [2]                    |
-| <kbd>C-c . v m</kbd> | `spotify-volume-mute-unmute` | Alternate the volume between 0 and 100 [2] |
-| <kbd>C-c . d</kbd>   | `spotify-select-device`      | Select a playback device [2]               |
+| Key                   | Function                     | Description                                |
+|:----------------------|:-----------------------------|:-------------------------------------------|
+| <kbd>PREFIX M-s</kbd> | `spotify-toggle-shuffle`     | Turn shuffle on/off [1]                    |
+| <kbd>PREFIX M-r</kbd> | `spotify-toggle-repeat`      | Turn repeat on/off [1]                     |
+| <kbd>PREFIX M-p</kbd> | `spotify-toggle-play`        | Play/pause                                 |
+| <kbd>PREFIX M-f</kbd> | `spotify-next-track`         | Next track                                 |
+| <kbd>PREFIX M-b</kbd> | `spotify-previous-track`     | Previous track                             |
+| <kbd>PREFIX p m</kbd> | `spotify-my-playlists`       | Show your playlists                        |
+| <kbd>PREFIX p f</kbd> | `spotify-featured-playlists` | Show the featured playlists                |
+| <kbd>PREFIX p s</kbd> | `spotify-playlist-search`    | Search for playlists                       |
+| <kbd>PREFIX p u</kbd> | `spotify-user-playlists`     | Show playlists for the given user          |
+| <kbd>PREFIX p c</kbd> | `spotify-create-playlist`    | Create a new playlist                      |
+| <kbd>PREFIX t r</kbd> | `spotify-recently-played`    | List of recently played tracks             |
+| <kbd>PREFIX t s</kbd> | `spotify-track-search`       | Search for tracks                          |
+| <kbd>PREFIX v u</kbd> | `spotify-volume-up`          | Increase the volume [2]                    |
+| <kbd>PREFIX v d</kbd> | `spotify-volume-down`        | Decrease the volume [2]                    |
+| <kbd>PREFIX v m</kbd> | `spotify-volume-mute-unmute` | Alternate the volume between 0 and 100 [2] |
+| <kbd>PREFIX d</kbd>   | `spotify-select-device`      | Select a playback device [2]               |
 
 The current song being played by the Spotify client is displayed in the mode
-line along with the player status (playing, paused). The interval in which the
-player status is updated can be configured via the
-`spotify-player-status-refresh-interval` variable:
+line or title bar (see `spotify-status-location`) along with the player status
+(playing, paused). The interval in which the player status is updated can be
+configured via the `spotify-player-status-refresh-interval` variable:
 
 ````el
 ;; Updates the player status every 10 seconds (default is 5)

--- a/spotify-remote.el
+++ b/spotify-remote.el
@@ -9,7 +9,9 @@
 (defcustom spotify-keymap-prefix nil
   "Spotify remote keymap prefix."
   :group 'spotify
-  :type 'string)
+  :type '(choice (const :tag "Disable keymap" nil)
+                 (string :tag "Prefix"))
+  :set #'spotify-set-mode-map)
 
 (defcustom spotify-status-location 'modeline
   "Specify where to show the player status: one of '(modeline title-bar nil)."
@@ -43,15 +45,19 @@
             (define-key map (kbd "t s") #'spotify-track-search)
             (define-key map (kbd "d") #'spotify-select-device)
             map)
-  "Keymap for Spotify commands after 'spotify-keymap-prefix'.")
+  "Keymap for Spotify commands after `spotify-keymap-prefix'.")
 (fset 'spotify-command-map spotify-command-map)
 
-(defvar spotify-mode-map
-  (let ((map (make-sparse-keymap)))
-    (when spotify-keymap-prefix
-      (define-key map spotify-keymap-prefix 'spotify-command-map))
-    map)
+(defvar spotify-mode-map nil
   "Keymap for Spotify remote mode.")
+
+(defun spotify-set-mode-map (variable value)
+  "Set value for `spotify-keymap-prefix' and update `spotify-mode-map’"
+  (set-default variable value)
+  (let ((map (make-sparse-keymap)))
+    (when value
+      (define-key map (kbd value) 'spotify-command-map))
+    (set 'spotify-mode-map map)))
 
 (defun spotify-add-frame-title-status (status title-section)
   "Return the TITLE-SECTION or part thereof with the player STATUS appended."
@@ -90,10 +96,8 @@ A positive prefix argument enables the mode, any other prefix
 argument disables it. From Lisp, argument omitted or nil enables
 the mode, `toggle' toggles the state.
 
-When Spotify Remote mode is enabled, it's possible to toggle
-the repeating and shuffling status of the running Spotify process.
-See commands \\[spotify-toggle-repeating] and
-\\[spotify-toggle-shuffling]."
+\\{spotify-mode-map}.
+"
   :group 'spotify
   :init-value nil
   :keymap spotify-mode-map


### PR DESCRIPTION
- Add a customize set function for correctly redefining
spotify-mode-map when spotify-keymap-prefix is set
- Update documentation to reflect this change


In particular, I found that the suggestion to do `(define-key spotify-mode-map (kbd "C-c .") 'spotify-command-map)` in the readme conflicted with the `spotify-keymap-prefix` variable.


----

#