### PR TITLE
Call status after activity & reduce number of calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ At this point, the client ID and the client secret are available, so set those v
 
 ### Remote Minor Mode
 
-Whenever you enable the `spotify-remote-mode` minor mode you get the following
+Whenever you enable the `global-spotify-remote-mode` minor mode you get the following
 key bindings:
 
 | Key                  | Function                     | Description                                |
@@ -178,7 +178,7 @@ key bindings:
 [1] D-Bus implementation for GNU/Linux do not support passing the context, so
 only the track under the cursor will be played
 
-The resulting buffer loads the `spotify-remote-mode` by default.
+The resulting buffer loads the `global-spotify-remote-mode` by default.
 
 **Tip:** In order to customize the number of items fetched per page, just change
 the variable `spotify-api-search-limit`:
@@ -244,7 +244,7 @@ bindings in the resulting buffer:
 | <kbd>u</kbd>     | Unfollows the current playlist                                      |
 | <kbd>M-RET</kbd> | Plays the track under the cursor in the context of the playlist [1] |
 
-Both buffers load the `spotify-remote-mode` by default.
+Both buffers load the `global-spotify-remote-mode` by default.
 
 [1] D-Bus implementation for GNU/Linux do not support passing the context, so
 only the track under the cursor will be played

--- a/spotify-controller.el
+++ b/spotify-controller.el
@@ -107,7 +107,7 @@ Apply SUFFIX to spotify-prefixed functions, applying ARGS."
   (let ((func-name (format "spotify-%s-%s" spotify-transport suffix)))
     (apply (intern func-name) args)
     (unless (string= suffix "player-status")
-      (spotify-player-status))))
+      (run-at-time 1 nil 'spotify-player-status))))
 
 (defun spotify-update-player-status (str)
   "Set the given STR to the player status, prefixed with the mode identifier."
@@ -156,20 +156,20 @@ This corresponds to the current REPEATING state."
         (setq player-status (replace-regexp-in-string "%p" (spotify-player-status-playing-indicator (gethash 'player_state json)) player-status))
         (spotify-update-player-status player-status)))))
 
+(defun spotify-timerp ()
+	"Predicate to determine if the spotify refresh timer is running."
+  (and (boundp 'spotify-timer) (timerp spotify-timer)))
+
 (defun spotify-start-player-status-timer ()
-  "Start the timer that will update the mode line according to the Spotify player status."
-  (spotify-stop-player-status-timer)
-  (when (> spotify-player-status-refresh-interval 0)
-    (let ((first-run (format "%d sec" spotify-player-status-refresh-interval))
-          (interval spotify-player-status-refresh-interval))
-      (setq spotify-timer
-            (run-at-time first-run interval 'spotify-player-status)))))
+ "Start the timer that will update the mode line according to the Spotify player status."
+ (when (and (not (spotify-timerp)) (> spotify-player-status-refresh-interval 0))
+     (setq spotify-timer
+       (run-at-time t spotify-player-status-refresh-interval 'spotify-player-status))))
 
 (defun spotify-stop-player-status-timer ()
-  "Stop the timer that is updating the mode line."
-  (when (and (boundp 'spotify-timer) (timerp spotify-timer))
-    (cancel-timer spotify-timer))
-  (spotify-player-status))
+ "Stop the timer that is updating the mode line."
+ (when (spotify-timerp)
+   (cancel-timer spotify-timer)))
 
 (defun spotify-player-status ()
   "Update the mode line to display the current Spotify player status."

--- a/spotify-device-select.el
+++ b/spotify-device-select.el
@@ -78,8 +78,7 @@
                                           ,device-id
                                           (lambda (json)
                                             (setq spotify-selected-device-id ,device-id)
-                                            (message "Device '%s' selected" ,name)
-                                            (spotify-update-player-status))))
+                                            (message "Device '%s' selected" ,name))))
                               'help-echo (format "Select '%s' for transport" name)))
                   (if is-active "X" "")
                   (if is-active (number-to-string volume) "")))

--- a/spotify-playlist-search.el
+++ b/spotify-playlist-search.el
@@ -29,9 +29,6 @@
     map)
   "Local keymap for `spotify-playlist-search-mode' buffers.")
 
-;; Enables the `global-spotify-remote-mode' in the track search buffer
-(add-hook 'spotify-playlist-search-mode-hook 'global-spotify-remote-mode)
-
 (define-derived-mode spotify-playlist-search-mode tabulated-list-mode "Playlist-Search"
   "Major mode for displaying the playlists returned by a Spotify search.")
 

--- a/spotify-playlist-search.el
+++ b/spotify-playlist-search.el
@@ -29,8 +29,8 @@
     map)
   "Local keymap for `spotify-playlist-search-mode' buffers.")
 
-;; Enables the `spotify-remote-mode' in the track search buffer
-(add-hook 'spotify-playlist-search-mode-hook 'spotify-remote-mode)
+;; Enables the `global-spotify-remote-mode' in the track search buffer
+(add-hook 'spotify-playlist-search-mode-hook 'global-spotify-remote-mode)
 
 (define-derived-mode spotify-playlist-search-mode tabulated-list-mode "Playlist-Search"
   "Major mode for displaying the playlists returned by a Spotify search.")

--- a/spotify-remote.el
+++ b/spotify-remote.el
@@ -66,7 +66,7 @@
     map)
   "Keymap for Spotify remote mode.")
 
-(define-minor-mode spotify-remote-mode
+(define-minor-mode global-spotify-remote-mode
   "Toggles Spotify Remote mode.
 A positive prefix argument enables the mode, any other prefix
 argument disables it. From Lisp, argument omitted or nil enables
@@ -78,9 +78,10 @@ See commands \\[spotify-toggle-repeating] and
 \\[spotify-toggle-shuffling]."
   :group 'spotify
   :init-value nil
+  :global t
   :keymap spotify-mode-map
   (let ((s `(,spotify-title-bar-separator (:eval (spotify-player-status-text)))))
-    (if spotify-remote-mode
+    (if global-spotify-remote-mode
         (progn
           (spotify-start-player-status-timer)
           (cond ((or (eq spotify-status-location 'modeline) (not (display-graphic-p)))
@@ -117,14 +118,6 @@ See commands \\[spotify-toggle-repeating] and
               'keymap spotify-remote-player-status-map
               'help-echo "mouse-1: Show Spotify.el menu"
               'mouse-face 'mode-line-highlight))
-
-(defun turn-on-spotify-remote-mode ()
-  "Turn the `spotify-remote-mode' on in the current buffer."
-  (spotify-remote-mode 1))
-
-(define-globalized-minor-mode global-spotify-remote-mode
-  spotify-remote-mode turn-on-spotify-remote-mode
-  :group 'spotify)
 
 (provide 'spotify-remote)
 ;;; spotify-remote.el ends here

--- a/spotify-track-search.el
+++ b/spotify-track-search.el
@@ -28,8 +28,8 @@
     map)
   "Local keymap for `spotify-track-search-mode' buffers.")
 
-;; Enables the `spotify-remote-mode' in the track search buffer
-(add-hook 'spotify-track-search-mode-hook 'spotify-remote-mode)
+;; Enables the `global-spotify-remote-mode' in the track search buffer
+(add-hook 'spotify-track-search-mode-hook 'global-spotify-remote-mode)
 
 (define-derived-mode spotify-track-search-mode tabulated-list-mode "Track-Search"
   "Major mode for displaying the track listing returned by a Spotify search.")

--- a/spotify-track-search.el
+++ b/spotify-track-search.el
@@ -28,9 +28,6 @@
     map)
   "Local keymap for `spotify-track-search-mode' buffers.")
 
-;; Enables the `global-spotify-remote-mode' in the track search buffer
-(add-hook 'spotify-track-search-mode-hook 'global-spotify-remote-mode)
-
 (define-derived-mode spotify-track-search-mode tabulated-list-mode "Track-Search"
   "Major mode for displaying the track listing returned by a Spotify search.")
 

--- a/spotify.el
+++ b/spotify.el
@@ -152,24 +152,24 @@ Prompt for the NAME and whether it should be made PUBLIC."
 
 (easy-menu-add-item nil '("Tools")
   '("Spotify"
-    ["Play/Pause"     spotify-toggle-play    :active spotify-remote-mode]
-    ["Previous Track" spotify-previous-track :active spotify-remote-mode]
-    ["Next Track"     spotify-next-track     :active spotify-remote-mode]
+    ["Play/Pause"     spotify-toggle-play    :active global-spotify-remote-mode]
+    ["Previous Track" spotify-previous-track :active global-spotify-remote-mode]
+    ["Next Track"     spotify-next-track     :active global-spotify-remote-mode]
     "--"
-    ["Select Device"  spotify-select-device      :active spotify-remote-mode]
-    ["Mute/Unmute"    spotify-volume-mute-unmute :active spotify-remote-mode]
+    ["Select Device"  spotify-select-device      :active global-spotify-remote-mode]
+    ["Mute/Unmute"    spotify-volume-mute-unmute :active global-spotify-remote-mode]
     "--"
-    ["Shuffle" spotify-toggle-shuffle :active spotify-remote-mode]
-    ["Repeat"  spotify-toggle-repeat  :active spotify-remote-mode]
+    ["Shuffle" spotify-toggle-shuffle :active global-spotify-remote-mode]
+    ["Repeat"  spotify-toggle-repeat  :active global-spotify-remote-mode]
     "--"
-    ["Search Tracks..."    spotify-track-search       :active spotify-remote-mode]
-    ["Featured Playlists"  spotify-featured-playlists :active spotify-remote-mode]
-    ["My Playlists"        spotify-my-playlists       :active spotify-remote-mode]
-    ["User Playlists..."   spotify-user-playlists     :active spotify-remote-mode]
-    ["Search Playlists..." spotify-playlist-search    :active spotify-remote-mode]
-    ["Create Playlist..."  spotify-create-playlist    :active spotify-remote-mode]
+    ["Search Tracks..."    spotify-track-search       :active global-spotify-remote-mode]
+    ["Featured Playlists"  spotify-featured-playlists :active global-spotify-remote-mode]
+    ["My Playlists"        spotify-my-playlists       :active global-spotify-remote-mode]
+    ["User Playlists..."   spotify-user-playlists     :active global-spotify-remote-mode]
+    ["Search Playlists..." spotify-playlist-search    :active global-spotify-remote-mode]
+    ["Create Playlist..."  spotify-create-playlist    :active global-spotify-remote-mode]
     "--"
-    ["Spotify Remote Mode" spotify-remote-mode :style toggle :selected spotify-remote-mode]))
+    ["Spotify Remote Mode" global-spotify-remote-mode :style toggle :selected global-spotify-remote-mode]))
 
 (defun spotify-remote-popup-menu ()
   "Popup menu when in spotify-remote-mode."


### PR DESCRIPTION
I attempted to handle various nested sets of callbacks to get the status after the API calls were complete but it truly was callback hell and required a lot of ugly, repetitive code. I think the right approach would be to use something like `aio` or whatever is considered the best async/await/promise library currently. As it stands, I just hacked in a 1s timer to get status after any call is made.

Also, using `define-globalized-minor-mode` was causing `spotify-remote-mode` to be called repeatedly on every switch from a buffer another buffer (or to the minibuffer). This was causing many unnecessary API calls because I had assumed the minor mode function would be called once. By specifying :global in the minor mode definition, the minor mode function is now called once for each toggle. This does prevent us from offering a buffer-specific minor mode, but that doesn't seem very useful anyway?