### PR TITLE
Use request.el for API calls

### DIFF
--- a/spotify-api.el
+++ b/spotify-api.el
@@ -231,7 +231,8 @@ Call CALLBACK with the parsed JSON response."
 							(let ((json-object-type 'hash-table)
 										 (json-array-type 'list)
 										 (json-key-type 'symbol))
-								(json-read)))
+								(when (> (buffer-size) 0)
+									(json-read))))
 		:encoding 'utf-8
 		:data data
 		:success (cl-function

--- a/spotify-api.el
+++ b/spotify-api.el
@@ -224,7 +224,8 @@ Call CALLBACK with the parsed JSON response."
 		:headers `(("Authorization" .
 								 ,(format "Bearer %s" (oauth2-token-access-token (spotify-oauth2-token))))
 								("Accept" . "application/json")
-								("Content-Type" . "application/json"))
+								("Content-Type" . "application/json")
+								("Content-Length" . ,(length data)))
 		:type method
 		:parser (lambda ()
 							(let ((json-object-type 'hash-table)

--- a/spotify-apple.el
+++ b/spotify-apple.el
@@ -65,7 +65,7 @@ Return the resulting status string."
 
 (defun spotify-apple-set-player-status-from-process-output (process output)
   "Set the OUTPUT of the player status PROCESS to the player status."
-  (spotify-replace-player-status-flags output)
+  (spotify-update-metadata output)
   (with-current-buffer (process-buffer process)
     (delete-region (point-min) (point-max))))
 

--- a/spotify-connect.el
+++ b/spotify-connect.el
@@ -48,8 +48,8 @@ Returns a JSON string in the format:
                       (format "\"player_repeating\":%s"
                               (if (string= (gethash 'repeat_state status) "off") "false" "true"))
                       "}")))
-         (spotify-replace-player-status-flags json)
-       (spotify-replace-player-status-flags nil)))))
+         (spotify-update-metadata json)
+       (spotify-update-metadata nil)))))
 
 (defmacro spotify-when-device-active (body)
   "Evaluate BODY when there is an active device, otherwise show an error message."

--- a/spotify-controller.el
+++ b/spotify-controller.el
@@ -160,27 +160,6 @@ This corresponds to the current REPEATING state."
       spotify-player-status-repeating-text
     spotify-player-status-not-repeating-text))
 
-(defun spotify-replace-player-status-flags (metadata)
-  "Compose the playing status string to be displayed in the player-status from METADATA."
-  (let* ((player-status spotify-player-status-format)
-         (duration-format "%m:%02s")
-         (json-object-type 'hash-table)
-         (json-key-type 'symbol)
-         (json (condition-case nil
-                   (json-read-from-string metadata)
-                 (error (spotify-update-player-status "")
-                        nil))))
-    (when json
-      (progn
-        (setq player-status (replace-regexp-in-string "%a" (truncate-string-to-width (gethash 'artist json) spotify-player-status-truncate-length 0 nil "...") player-status))
-        (setq player-status (replace-regexp-in-string "%t" (truncate-string-to-width (gethash 'name json) spotify-player-status-truncate-length 0 nil "...") player-status))
-        (setq player-status (replace-regexp-in-string "%n" (number-to-string (gethash 'track_number json)) player-status))
-        (setq player-status (replace-regexp-in-string "%l" (format-seconds duration-format (/ (gethash 'duration json) 1000)) player-status))
-        (setq player-status (replace-regexp-in-string "%s" (spotify-player-status-shuffling-indicator (gethash 'player_shuffling json)) player-status))
-        (setq player-status (replace-regexp-in-string "%r" (spotify-player-status-repeating-indicator (gethash 'player_repeating json)) player-status))
-        (setq player-status (replace-regexp-in-string "%p" (spotify-player-status-playing-indicator (gethash 'player_state json)) player-status))
-        (spotify-update-player-status player-status)))))
-
 (defun spotify-start-player-status-timer ()
   "Start the timer that will update the mode line according to the Spotify player status."
   (spotify-stop-player-status-timer)

--- a/spotify-controller.el
+++ b/spotify-controller.el
@@ -101,6 +101,9 @@ The following placeholders are supported:
 (defvar spotify-player-status ""
   "The text to be displayed in the global mode line or title bar.")
 
+(defvar spotify-player-metadata nil
+  "The metadata about the currently playing track.")
+
 (defun spotify-apply (suffix &rest args)
   "Simple facility to emulate multimethods.
 Apply SUFFIX to spotify-prefixed functions, applying ARGS."
@@ -108,6 +111,28 @@ Apply SUFFIX to spotify-prefixed functions, applying ARGS."
     (apply (intern func-name) args)
     (unless (string= suffix "player-status")
       (spotify-player-status))))
+
+(defun spotify-update-metadata (metadata)
+  "Compose the playing status string to be displayed in the mode-line from METADATA."
+  (let* ((player-status spotify-player-status-format)
+         (duration-format "%m:%02s")
+         (json-object-type 'hash-table)
+         (json-key-type 'symbol)
+         (json (condition-case nil
+                   (json-read-from-string metadata)
+                 (error (spotify-update-player-status "")
+                        nil))))
+    (when json
+      (progn
+        (setq player-status (replace-regexp-in-string "%a" (truncate-string-to-width (gethash 'artist json) spotify-player-status-truncate-length 0 nil "...") player-status))
+        (setq player-status (replace-regexp-in-string "%t" (truncate-string-to-width (gethash 'name json) spotify-player-status-truncate-length 0 nil "...") player-status))
+        (setq player-status (replace-regexp-in-string "%n" (number-to-string (gethash 'track_number json)) player-status))
+        (setq player-status (replace-regexp-in-string "%l" (format-seconds duration-format (/ (gethash 'duration json) 1000)) player-status))
+        (setq player-status (replace-regexp-in-string "%s" (spotify-player-status-shuffling-indicator (gethash 'player_shuffling json)) player-status))
+        (setq player-status (replace-regexp-in-string "%r" (spotify-player-status-repeating-indicator (gethash 'player_repeating json)) player-status))
+        (setq player-status (replace-regexp-in-string "%p" (spotify-player-status-playing-indicator (gethash 'player_state json)) player-status))
+        (spotify-update-player-status player-status)
+        (setq spotify-player-metadata json)))))
 
 (defun spotify-update-player-status (str)
   "Set the given STR to the player status, prefixed with the mode identifier."

--- a/spotify-dbus.el
+++ b/spotify-dbus.el
@@ -54,7 +54,7 @@
               (track-number  (car (car (cdr (assoc "xesam:trackNumber" metadata)))))
               (duration      (/ (car (car (cdr (assoc "mpris:length" metadata)))) 1000)))
           (if (> track-number 0)
-              (spotify-replace-player-status-flags
+              (spotify-update-metadata
                (concat "{"
                        " \"artist\": \"" artist "\""
                        ",\"duration\": " (number-to-string duration) ""


### PR DESCRIPTION
Also includes serializing & deserializing the OAuth2 token so the user doesn't have to launch a browser every time they want to use Spotify.

Closes #63 
Closes #43 